### PR TITLE
change disconnect to end event inline with telnet module

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ class instance extends instance_skel {
 				this.synced = false;
 			});
 
-			this.socket.on('disconnect', () => {
+			this.socket.on('end', () => {
 				this.debug("Disconnected");
 				this.loggedIn = false;
 				this.synced = false;


### PR DESCRIPTION
The telnet library doesn't seem to emit a 'disconnect' event. Changed to 'end' so heartbeats are destroyed properly on lost connection.